### PR TITLE
Potential fix for code scanning alert no. 2: Hard-coded cryptographic value

### DIFF
--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -4,12 +4,17 @@ use crate::models::user::User;
 use crate::settings::SETTINGS;
 use crate::utils::models::ModelExt;
 use crate::utils::token;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub async fn create_user<T: AsRef<str>>(email: T) -> Result<User, Error> {
     let name = "Nahuel";
-    let password = "Password1";
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let password = format!("TestPassword1!{}", timestamp);
 
-    let password_hash = hash_password(password).await?;
+    let password_hash = hash_password(&password).await?;
     let user = User::new(name, email.as_ref(), password_hash);
     let user = User::create(user).await?;
 


### PR DESCRIPTION
Potential fix for [https://github.com/arielsrv/rustapi/security/code-scanning/2](https://github.com/arielsrv/rustapi/security/code-scanning/2)

General fix: remove hard-coded password literals and generate per-call test passwords dynamically (or inject them via parameters/env), then hash as before.

Best minimal fix without changing existing functionality: in `src/tests/utils.rs`, replace the hard-coded `"Password1"` with a generated password string derived from randomness/time so each created user gets a non-hardcoded credential while preserving the same flow (`hash_password` → `User::new` → `User::create`). Since we can only edit shown code and should avoid broad refactors, update `create_user` locally by generating a password at runtime (e.g., with `SystemTime` nanos), then pass it to `hash_password`.

Needed changes:
- In `src/tests/utils.rs`, add `use std::time::{SystemTime, UNIX_EPOCH};`.
- In `create_user`, replace `let password = "Password1";` with runtime-generated `String`.
- Keep all existing behavior otherwise unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
