### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [ push ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/arielsrv/rustapi/security/code-scanning/1](https://github.com/arielsrv/rustapi/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (best here since there is only one job and all current steps share the same needs). Use:

- `contents: read`

This is the minimal least-privilege baseline and aligns with CodeQL guidance.  
Edit `.github/workflows/test.yml` near the top-level keys (after `on` is a clean location), without changing workflow behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration with explicit token permission settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->